### PR TITLE
Animate category selection screen waves

### DIFF
--- a/lib/screens/category_selection_screen.dart
+++ b/lib/screens/category_selection_screen.dart
@@ -10,6 +10,7 @@ import '../services/storage_service.dart';
 import '../services/firestore_service.dart';
 import '../services/online_game_navigation_service.dart';
 import '../providers/session_providers.dart';
+import '../widgets/radial_ripple_background.dart';
 
 class CategorySelectionScreen extends ConsumerStatefulWidget {
   final int teamIndex;
@@ -242,163 +243,176 @@ class _CategorySelectionScreenState
     }
 
     return Scaffold(
-      body: SafeArea(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-          children: [
-            Expanded(
-              child: Center(
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text(
-                      widget.displayString,
-                      style: Theme.of(context).textTheme.headlineMedium,
-                      textAlign: TextAlign.center,
-                    ),
-                    const SizedBox(height: 40),
-                    // Show waiting message for non-active teams in online games
-                    if (widget.sessionId != null && !_isCurrentTeamActive) ...[
-                      Container(
-                        padding: const EdgeInsets.all(16),
-                        margin: const EdgeInsets.only(bottom: 20),
-                        decoration: BoxDecoration(
-                          color: Colors.orange.withOpacity(0.1),
-                          borderRadius: BorderRadius.circular(12),
-                          border:
-                              Border.all(color: Colors.orange.withOpacity(0.3)),
+      body: Stack(
+        children: [
+          const Positioned.fill(
+            child: RadialRippleBackground(
+              centerAlignment: Alignment.center,
+              duration: Duration(seconds: 12),
+            ),
+          ),
+          SafeArea(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Center(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          widget.displayString,
+                          style: Theme.of(context).textTheme.headlineMedium,
+                          textAlign: TextAlign.center,
                         ),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            const Icon(Icons.hourglass_empty,
-                                color: Colors.orange),
-                            const SizedBox(width: 8),
-                            Text(
-                              'Waiting for ${widget.displayString} to select category...',
-                              style: const TextStyle(
-                                color: Colors.orange,
-                                fontWeight: FontWeight.w500,
-                              ),
+                        const SizedBox(height: 40),
+                        // Show waiting message for non-active teams in online games
+                        if (widget.sessionId != null && !_isCurrentTeamActive) ...[
+                          Container(
+                            padding: const EdgeInsets.all(16),
+                            margin: const EdgeInsets.only(bottom: 20),
+                            decoration: BoxDecoration(
+                              color: Colors.orange.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(
+                                  color: Colors.orange.withOpacity(0.3)),
                             ),
-                          ],
-                        ),
-                      ),
-                    ],
-                    GestureDetector(
-                      onTap: (_isCurrentTeamActive &&
-                              !_isSpinning &&
-                              _selectedCategory == null)
-                          ? _spinCategories
-                          : null,
-                      child: AnimatedBuilder(
-                        animation: _scaleController,
-                        builder: (context, child) {
-                          return Transform.scale(
-                            scale: _scaleAnimation.value,
-                            child: Container(
-                              width: 300,
-                              height: 300,
-                              decoration: BoxDecoration(
-                                shape: BoxShape.circle,
-                                border: Border.all(
-                                  color: _currentCategory.isNotEmpty
-                                      ? CategoryRegistry
-                                              .getCategoryByDisplayName(
-                                                  _currentCategory)
-                                          .color
-                                      : teamColor.text,
-                                  width: 2,
-                                ),
-                              ),
-                              child: Center(
-                                child: AnimatedSwitcher(
-                                  duration: const Duration(milliseconds: 150),
-                                  transitionBuilder: (Widget child,
-                                      Animation<double> animation) {
-                                    return FadeTransition(
-                                      opacity: animation,
-                                      child: child,
-                                    );
-                                  },
-                                  child: Text(
-                                    _currentCategory.isEmpty
-                                        ? (_isCurrentTeamActive
-                                            ? 'TAP TO SPIN\nFOR CATEGORY!'
-                                            : 'WAITING...')
-                                        : _currentCategory,
-                                    key: ValueKey<String>(_currentCategory),
-                                    textAlign: TextAlign.center,
-                                    style: Theme.of(context)
-                                        .textTheme
-                                        .displayLarge
-                                        ?.copyWith(
-                                          color: _currentCategory.isNotEmpty
-                                              ? CategoryRegistry
-                                                      .getCategoryByDisplayName(
-                                                          _currentCategory)
-                                                  .color
-                                              : teamColor.text,
-                                          fontSize: _currentCategory.isEmpty
-                                              ? 32
-                                              : null,
-                                        ),
+                            child: Row(
+                              mainAxisAlignment: MainAxisAlignment.center,
+                              children: [
+                                const Icon(Icons.hourglass_empty,
+                                    color: Colors.orange),
+                                const SizedBox(width: 8),
+                                Text(
+                                  'Waiting for ${widget.displayString} to select category...',
+                                  style: const TextStyle(
+                                    color: Colors.orange,
+                                    fontWeight: FontWeight.w500,
                                   ),
                                 ),
-                              ),
+                              ],
                             ),
-                          );
-                        },
-                      ),
+                          ),
+                        ],
+                        GestureDetector(
+                          onTap: (_isCurrentTeamActive &&
+                                  !_isSpinning &&
+                                  _selectedCategory == null)
+                              ? _spinCategories
+                              : null,
+                          child: AnimatedBuilder(
+                            animation: _scaleController,
+                            builder: (context, child) {
+                              return Transform.scale(
+                                scale: _scaleAnimation.value,
+                                child: Container(
+                                  width: 300,
+                                  height: 300,
+                                  decoration: BoxDecoration(
+                                    shape: BoxShape.circle,
+                                    border: Border.all(
+                                      color: _currentCategory.isNotEmpty
+                                          ? CategoryRegistry
+                                                  .getCategoryByDisplayName(
+                                                      _currentCategory)
+                                              .color
+                                          : teamColor.text,
+                                      width: 2,
+                                    ),
+                                  ),
+                                  child: Center(
+                                    child: AnimatedSwitcher(
+                                      duration:
+                                          const Duration(milliseconds: 150),
+                                      transitionBuilder: (Widget child,
+                                          Animation<double> animation) {
+                                        return FadeTransition(
+                                          opacity: animation,
+                                          child: child,
+                                        );
+                                      },
+                                      child: Text(
+                                        _currentCategory.isEmpty
+                                            ? (_isCurrentTeamActive
+                                                ? 'TAP TO SPIN\nFOR CATEGORY!'
+                                                : 'WAITING...')
+                                            : _currentCategory,
+                                        key: ValueKey<String>(
+                                            _currentCategory),
+                                        textAlign: TextAlign.center,
+                                        style: Theme.of(context)
+                                            .textTheme
+                                            .displayLarge
+                                            ?.copyWith(
+                                              color: _currentCategory.isNotEmpty
+                                                  ? CategoryRegistry
+                                                          .getCategoryByDisplayName(
+                                                              _currentCategory)
+                                                      .color
+                                                  : teamColor.text,
+                                              fontSize:
+                                                  _currentCategory.isEmpty
+                                                      ? 32
+                                                      : null,
+                                            ),
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                        const SizedBox(height: 40),
+                      ],
                     ),
-                    const SizedBox(height: 40),
-                  ],
+                  ),
                 ),
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(20.0),
-              child: AnimatedOpacity(
-                opacity: _selectedCategory != null ? 1.0 : 0.0,
-                duration: const Duration(milliseconds: 300),
-                child: Row(
-                  children: [
-                    Expanded(
-                      child: TeamColorButton(
-                        text: 'Next',
-                        icon: Icons.arrow_forward,
-                        color: uiColors[1], // Green
-                        onPressed: (_isCurrentTeamActive &&
-                                _selectedCategory != null)
-                            ? () async {
-                                if (widget.sessionId != null) {
-                                  // For online games, update game state with selected category and change status
-                                  await FirestoreService.fromCategorySelection(
-                                    widget.sessionId!,
-                                    selectedCategory: _selectedCategory!,
-                                  );
-                                } else {
-                                  // For local games, use the existing navigation service
-                                  GameNavigationService
-                                      .navigateFromCategorySelection(
-                                    context,
-                                    ref,
-                                    widget.teamIndex,
-                                    widget.roundNumber,
-                                    widget.turnNumber,
-                                    _selectedCategory!,
-                                  );
-                                }
-                              }
-                            : null,
-                      ),
+                Padding(
+                  padding: const EdgeInsets.all(20.0),
+                  child: AnimatedOpacity(
+                    opacity: _selectedCategory != null ? 1.0 : 0.0,
+                    duration: const Duration(milliseconds: 300),
+                    child: Row(
+                      children: [
+                        Expanded(
+                          child: TeamColorButton(
+                            text: 'Next',
+                            icon: Icons.arrow_forward,
+                            color: uiColors[1], // Green
+                            onPressed: (_isCurrentTeamActive &&
+                                    _selectedCategory != null)
+                                ? () async {
+                                    if (widget.sessionId != null) {
+                                      // For online games, update game state with selected category and change status
+                                      await FirestoreService.fromCategorySelection(
+                                        widget.sessionId!,
+                                        selectedCategory: _selectedCategory!,
+                                      );
+                                    } else {
+                                      // For local games, use the existing navigation service
+                                      GameNavigationService
+                                          .navigateFromCategorySelection(
+                                        context,
+                                        ref,
+                                        widget.teamIndex,
+                                        widget.roundNumber,
+                                        widget.turnNumber,
+                                        _selectedCategory!,
+                                      );
+                                    }
+                                  }
+                                : null,
+                          ),
+                        ),
+                      ],
                     ),
-                  ],
+                  ),
                 ),
-              ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/widgets/radial_ripple_background.dart
+++ b/lib/widgets/radial_ripple_background.dart
@@ -1,0 +1,142 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+
+class RadialRippleBackground extends StatefulWidget {
+  final Alignment centerAlignment;
+  final Duration duration;
+
+  const RadialRippleBackground({
+    super.key,
+    this.centerAlignment = Alignment.center,
+    this.duration = const Duration(seconds: 10),
+  });
+
+  @override
+  State<RadialRippleBackground> createState() => _RadialRippleBackgroundState();
+}
+
+class _RadialRippleBackgroundState extends State<RadialRippleBackground>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller =
+      AnimationController(vsync: this, duration: widget.duration)..repeat();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RepaintBoundary(
+      child: AnimatedBuilder(
+        animation: _controller,
+        builder: (_, __) => CustomPaint(
+          painter: _RadialRipplesPainter(
+            t: _controller.value,
+            centerAlignment: widget.centerAlignment,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RadialRipplesPainter extends CustomPainter {
+  final double t; // 0..1 loop
+  final Alignment centerAlignment;
+
+  _RadialRipplesPainter({required this.t, required this.centerAlignment});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // Dark background gradient to match HomeScreen
+    final Paint bg = Paint()
+      ..shader = const RadialGradient(
+        center: Alignment(0, -0.2),
+        radius: 1.2,
+        colors: [Color(0xFF0B1020), Color(0xFF0E162A)],
+      ).createShader(Offset.zero & size);
+    canvas.drawRect(Offset.zero & size, bg);
+
+    // Determine ripple origin within the canvas based on alignment
+    final Offset center = Offset(
+      size.width * (0.5 + 0.5 * centerAlignment.x),
+      size.height * (0.5 + 0.5 * centerAlignment.y),
+    );
+
+    final double maxRadius = _maxDistanceToCorners(center, size);
+
+    // Color palette aligned with HomeScreen hues
+    const List<Color> palette = [
+      Color(0xFF5EB1FF), // blue
+      Color(0xFF7A5CFF), // purple
+      Color(0xFFFF6680), // pink/red
+      Color(0xFFFFA14A), // orange
+      Color(0xFFFFD166), // yellow
+      Color(0xFF4CD295), // green
+    ];
+
+    // Base spacing and speed
+    const double baseSpacing = 22.0;
+    const double speedSpacingPerLoop = baseSpacing * 2.0; // outward per loop
+
+    // Start so that rings wrap around seamlessly
+    final double shift = t * speedSpacingPerLoop;
+    final double start = -baseSpacing * 3 + shift;
+
+    // Draw outward-moving concentric rings
+    // Slight frequency variations per ring via i-based adjustment
+    final Paint ringPaint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.3;
+
+    // Cap the number of rings conservatively for performance
+    for (int i = 0; i < 120; i++) {
+      // Vary spacing slightly per ring to create subtle frequency differences
+      final double spacingJitter = 1.0 + 0.06 * math.sin(i * 0.85);
+      final double ringSpacing = baseSpacing * spacingJitter;
+      final double radius = start + i * ringSpacing;
+      if (radius < 0) continue;
+      if (radius > maxRadius + baseSpacing * 2) break;
+
+      // Small pulsation to avoid static equal distances
+      final double pulsate = 3.0 * math.sin((t * math.pi * 2 * 0.9) + i * 0.55);
+      final double r = radius + pulsate;
+
+      // Color selection with slight temporal drift
+      final int pi0 = i % palette.length;
+      final Color base = palette[pi0];
+      final HSLColor hsl = HSLColor.fromColor(base);
+      final double hueDrift = (math.sin(i * 0.33 + t * math.pi * 2) * 4.0);
+      final double lightness = (hsl.lightness * 0.95).clamp(0.0, 1.0);
+      final Color color = hsl
+          .withHue((hsl.hue + hueDrift) % 360)
+          .withLightness(lightness)
+          .toColor()
+          .withOpacity(0.75);
+
+      ringPaint.color = color;
+      canvas.drawCircle(center, r, ringPaint);
+    }
+  }
+
+  double _maxDistanceToCorners(Offset c, Size s) {
+    final List<Offset> corners = [
+      Offset.zero,
+      Offset(s.width, 0),
+      Offset(0, s.height),
+      Offset(s.width, s.height),
+    ];
+    double maxD = 0;
+    for (final corner in corners) {
+      final double d = (corner - c).distance;
+      if (d > maxD) maxD = d;
+    }
+    return maxD;
+  }
+
+  @override
+  bool shouldRepaint(covariant _RadialRipplesPainter oldDelegate) =>
+      oldDelegate.t != t || oldDelegate.centerAlignment != centerAlignment;
+}


### PR DESCRIPTION
Add an animated radial ripple background to the category selection screen, mirroring the home screen's aesthetic.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8b10545-ff2e-4f10-9da1-c96ef81ee0b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8b10545-ff2e-4f10-9da1-c96ef81ee0b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

